### PR TITLE
Update environment.yml to fix crispio dependencies.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
     - conda-forge::pigz
     - conda-forge::unzip
     - pip:
-        - "crispio[fit_cuda_local]>=0.0.4"
+        - "crispio[fit_cuda12_local]>=0.0.4"
         - 'carabiner-tools[mpl,pd]>=0.0.4'
         - 'cutadapt>=5.0'
         - 'multiqc>=1.27'


### PR DESCRIPTION
Fixes #4 

Updated dependencies flag for crispio installation.

Dependencies flag was changed in crispio fitness branch in commit 99c3396 from fit_cuda_local to fit_cuda12_local.

Fix not yet tested.